### PR TITLE
build: Exclude auto-approve from merge queue

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -2,7 +2,6 @@
 name: Dependabot auto-approve
 on:
   pull_request:
-  merge_group:
 
 permissions:
   contents: write


### PR DESCRIPTION
Exclude Dependabot auto-approve from merge queue.
